### PR TITLE
Upgrading Node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "css-loader": "^1.0.1",
     "file-loader": "^3.0.1",
     "mini-css-extract-plugin": "^0.5.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.13.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",


### PR DESCRIPTION
Node-Sass 4.13.0 supports Node version 13 and is backwards compatible with older versions. Node-sass 4.10 doesn't even support the current LTS and it has a lot of semi-critical bug fixes.