### PR TITLE
Added .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _site/
 
 # Misc
 .DS_Store
+.env


### PR DESCRIPTION
Yo, it's a bad idea to version .env- files. You should create a boilerplate .env file with all the necessary fields (in your case, the webmentions token) and version that without any values, then rename the file to .env and add the values for publishing and building the project.

I strongly recommend that you regenerate a new token and don't push it to git.